### PR TITLE
Impl-3: Adding Model Class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,12 @@ project(SEP25 VERSION 0.1.0 LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Add src directory
-file(GLOB SRC_FILES src/*.cpp)
-add_executable(sep25_main ${SRC_FILES})
+# Gather source files, excluding main.cpp
+file(GLOB_RECURSE SRC_FILES src/*.cpp)
+list(FILTER SRC_FILES EXCLUDE REGEX ".*/main.cpp$")
+
+# Add main executable
+add_executable(sep25_main src/main.cpp ${SRC_FILES})
 target_include_directories(sep25_main PUBLIC ${CMAKE_BINARY_DIR})
 include_directories(SYSTEM ${CMAKE_CXX_STANDARD_LIBRARIES})
 
@@ -31,7 +34,7 @@ enable_testing()
 
 # Create test executable
 file(GLOB TEST_FILES test/*.cpp)
-add_executable(sep25_tests ${TEST_FILES})
+add_executable(sep25_tests ${SRC_FILES} ${TEST_FILES})
 
 # Link GoogleTest
 target_link_libraries(sep25_tests 

--- a/src/Models/DumbModel.cpp
+++ b/src/Models/DumbModel.cpp
@@ -1,0 +1,26 @@
+#include <vector>
+#include <random>
+#include <ctime>
+
+#include "DumbModel.hpp"
+
+DumbModel::DumbModel(int dimensions, int dimensionSize) : Model(dimensions, dimensionSize) {
+    std::srand(std::time(nullptr));
+}
+
+std::vector<int> DumbModel::get_next_query() {
+    int D = this->stateSpace->get_dimensions();
+    int K = this->stateSpace->get_dimension_size();
+    std::vector<int> nextQuery(D, 0);
+
+    for (auto &var : nextQuery){
+        var = std::rand() % K;
+    }
+
+    return nextQuery;
+}
+
+void DumbModel::update_prediction(std::vector<int> query, double result) {
+    stateSpace->set(query, result);
+}
+

--- a/src/Models/DumbModel.hpp
+++ b/src/Models/DumbModel.hpp
@@ -1,0 +1,14 @@
+#ifndef DUMB_MODEL_H
+#define DUMB_MODEL_H
+
+#include "Model.hpp"
+
+class DumbModel : public Model {
+public:
+    DumbModel(int dimensions, int dimensionSize);
+    std::vector<int> get_next_query() override;
+    void update_prediction(std::vector<int> query, double result) override;
+};
+
+
+#endif //DUMB_MODEL_H

--- a/src/Models/Model.hpp
+++ b/src/Models/Model.hpp
@@ -1,0 +1,18 @@
+#ifndef MODEL_H
+#define MODEL_H
+#include <vector>
+
+#include "../StateSpace/StateSpace.hpp"
+
+class Model {
+protected:
+    StateSpace* stateSpace = nullptr;
+public:
+        Model(int dimensions, int dimensionSize): stateSpace(new StateSpace(dimensions, dimensionSize)) {};
+        virtual std::vector<int> get_next_query() = 0;
+        virtual void update_prediction(std::vector<int> query, double result) = 0;
+        StateSpace get_state_space() const { return *stateSpace; };
+};
+
+
+#endif // MODEL_H

--- a/src/StateSpace/StateSpace.cpp
+++ b/src/StateSpace/StateSpace.cpp
@@ -1,58 +1,35 @@
-/* 
+#include "StateSpace.hpp"
 
-StateSpace.hpp
-Implements a StateSpace class that allows for interactions with an n-dimensional integer indexed array.
-
-*/
-
-
-#ifndef STATESPACE_H
-#define STATESPACE_H
-#include <vector>
-#include <iostream>
-#include <cmath>
-
-class StateSpace {
-private:
-    std::vector<double> stateSpace;
-    const int dimensions;
-    const int dimensionSize;
-
-    int coords_to_index(const std::vector<int>& coords) const {
-        if (coords.size() != this->dimensions) 
-            throw std::invalid_argument("Index has Invalid Number of Dimensions");
-        int rawIndex = 0;
-        int multiplier = 1;
-        for (int i = dimensions - 1; i > -1; i--) {
-            if (coords[i] < 0 || coords[i] >= this->dimensionSize) 
-                throw std::out_of_range("Coordinate at index [" + std::to_string(i) + "] out of range");
-            rawIndex += coords[i] * multiplier;
-            multiplier *= dimensionSize;
-        }
-        return rawIndex;
+int StateSpace::coords_to_index(const std::vector<int>& coords) const {
+    if (coords.size() != this->dimensions) 
+        throw std::invalid_argument("Index has Invalid Number of Dimensions");
+    int rawIndex = 0;
+    int multiplier = 1;
+    for (int i = dimensions - 1; i > -1; i--) {
+        if (coords[i] < 0 || coords[i] >= this->dimensionSize) 
+            throw std::out_of_range("Coordinate at index [" + std::to_string(i) + "] out of range");
+        rawIndex += coords[i] * multiplier;
+        multiplier *= dimensionSize;
     }
+    return rawIndex;
+}
 
-public:
-    StateSpace(int dimensions, int dimensionSize, double initialValues = 0.0) 
-        : dimensions(dimensions), dimensionSize(dimensionSize), stateSpace(std::pow(dimensionSize, dimensions), initialValues) {}
+StateSpace::StateSpace(int dimensions, int dimensionSize, double initialValues) 
+    : dimensions(dimensions), dimensionSize(dimensionSize), stateSpace(std::pow(dimensionSize, dimensions), initialValues) {}
 
 
-    int get_dimensions() const {
-        return this->dimensions;
-    }
+int StateSpace::get_dimensions() const {
+    return this->dimensions;
+}
 
-    int get_dimension_size() const {
-        return this->dimensionSize;
-    }
-    
-    double get(const std::vector<int>& coords) const {
-        return this->stateSpace[coords_to_index(coords)];
-    }
+int StateSpace::get_dimension_size() const {
+    return this->dimensionSize;
+}
 
-    double set(const std::vector<int>& coords, double value) {
-        return this->stateSpace[coords_to_index(coords)] = value;
-    }
-    
-};
+double StateSpace::get(const std::vector<int>& coords) const {
+    return this->stateSpace[coords_to_index(coords)];
+}
 
-#endif // STATESPACE_H
+double StateSpace::set(const std::vector<int>& coords, double value) {
+    return this->stateSpace[coords_to_index(coords)] = value;
+}

--- a/src/StateSpace/StateSpace.hpp
+++ b/src/StateSpace/StateSpace.hpp
@@ -1,0 +1,36 @@
+/* 
+
+StateSpace.hpp
+Implements a StateSpace class that allows for interactions with an n-dimensional integer indexed array.
+
+*/
+
+
+#ifndef STATESPACE_H
+#define STATESPACE_H
+#include <vector>
+#include <iostream>
+#include <cmath>
+
+class StateSpace {
+private:
+    std::vector<double> stateSpace;
+    const int dimensions;
+    const int dimensionSize;
+
+    int coords_to_index(const std::vector<int>& coords) const;
+
+public:
+    StateSpace(int dimensions, int dimensionSize, double initialValues = 0.0);
+
+    int get_dimensions() const;
+
+    int get_dimension_size() const;
+    
+    double get(const std::vector<int>& coords) const;
+
+    double set(const std::vector<int>& coords, double value);
+    
+};
+
+#endif // STATESPACE_H

--- a/test/ModelTest.cpp
+++ b/test/ModelTest.cpp
@@ -1,0 +1,45 @@
+#include <iostream>
+#include <gtest/gtest.h>
+
+#include "../src/Models/DumbModel.hpp"
+
+using namespace std;
+
+TEST(OneDimensionalModel, TestsModel1D){
+    DumbModel myModel(1, 10);
+
+    // test functionality
+    EXPECT_EQ(1, myModel.get_next_query().size());
+    EXPECT_EQ(0, myModel.get_state_space().get({1}));
+    EXPECT_NO_THROW(myModel.update_prediction({1}, 1));
+    EXPECT_EQ(1, myModel.get_state_space().get({1}));
+
+    // check that created array is correct size
+    EXPECT_NO_THROW(myModel.get_state_space().get({0}));
+    EXPECT_NO_THROW(myModel.get_state_space().get({9}));
+    EXPECT_THROW(myModel.get_state_space().get({10}), std::out_of_range);
+}
+
+TEST(MultDimensionModel, TestsModelND){
+    for (int i = 1; i < 6; i++){
+        DumbModel myModel(i, 10);
+        
+        vector<int> queryPoint(i, 0);
+
+        // test functionality
+        EXPECT_EQ(i, myModel.get_next_query().size());
+        EXPECT_EQ(0, myModel.get_state_space().get(queryPoint));
+        EXPECT_NO_THROW(myModel.update_prediction(queryPoint, 1));
+        EXPECT_EQ(1, myModel.get_state_space().get(queryPoint));
+
+        // check that created array is correct size
+        for (int j = 0; j < i; j++){
+            EXPECT_NO_THROW(myModel.get_state_space().get(queryPoint));
+            queryPoint[j] = 9;
+            EXPECT_NO_THROW(myModel.get_state_space().get(queryPoint));
+            queryPoint[j] = 10;
+            EXPECT_THROW(myModel.get_state_space().get(queryPoint), std::out_of_range);
+            queryPoint[j] = 9;
+        }
+    }
+}

--- a/test/StateSpaceTest.cpp
+++ b/test/StateSpaceTest.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 #include <gtest/gtest.h>
 
-#include "../src/StateSpace/StateSpace.cpp"
+#include "../src/StateSpace/StateSpace.hpp"
 
 using namespace std;
 


### PR DESCRIPTION
Added Model abstract class as well as a DumbModel. DumbModel allows for testing of inheritance and will act as a template for future models. Tests were added that test the DumbModel's StateSpace creation and other core functionality.

Noticed issue with build not including source files when creating the test executable -> fixed issue.

Modified StateSpace class to be inline with other files.

