### PR TITLE
Impl 5: implementing InputOutput class and command line subclass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Build artifacts
 /build/
 _deps/
+/build-windows/
 
 # Compiled files
 *.o

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,3 +45,10 @@ target_link_libraries(sep25_tests
 # Add tests
 add_test(NAME UnitTests COMMAND sep25_tests)
 
+# If building with MinGW (Windows cross-compile), make standalone exe
+if(MINGW)
+    message(STATUS "Building with MinGW, enabling static linking")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static")
+endif()
+
+

--- a/README.md
+++ b/README.md
@@ -11,8 +11,23 @@ This project uses CMake as its build system. The project structure includes:
 
 - C++20 compatible compiler
 - CMake 3.16 or higher
+- MinGW ( see below instructions)
 
-### Build Instructions
+### MinGW Installation
+1. Install MinGW:
+```bash
+sudo apt update
+sudo apt install mingw-w64
+```
+
+2. Validate Installation:
+```bash
+which x86_64-w64-mingw32-gcc 
+which x86_64-w64-mingw32-g++
+```
+
+
+### Local Build Instructions
 
 1. Create the build directory and navigate to it:
 `mkdir -p build && cd build`
@@ -20,7 +35,14 @@ This project uses CMake as its build system. The project structure includes:
 `cmake ..`
 3. Build the project:
 `cmake --build .`
-   ```
+
+### Windows Cross Compilation Instructions
+1. Create build folder `mkdir build-windows && cd build-windows`
+2. Generate the build files `cmake -DCMAKE_TOOLCHAIN_FILE=../windows-toolchain.cmake ..`
+3. Build the project `cmake --build . --config Release`
+4. .exe is located in `./build-windows/sep25_main.exe` this cannot be run locally on a linux machine
+can be copied to a windows machine for testing.
+
 
 ### Running the Application
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ which x86_64-w64-mingw32-g++
 3. Build the project:
 `cmake --build .`
 
-### Windows Cross Compilation Instructions
+### Windows Cross-Compilation Instructions
 1. Create build folder `mkdir build-windows && cd build-windows`
 2. Generate the build files `cmake -DCMAKE_TOOLCHAIN_FILE=../windows-toolchain.cmake ..`
 3. Build the project `cmake --build . --config Release`

--- a/src/InputOutput/CommandLineInputOutput.cpp
+++ b/src/InputOutput/CommandLineInputOutput.cpp
@@ -7,7 +7,7 @@ void CommandLineInputOutput::set_IO(){
         instance = new CommandLineInputOutput;
 }
 
-double CommandLineInputOutput::send_query_recieve_result(std::vector<int> &query){
+double CommandLineInputOutput::send_query_recieve_result(const std::vector<int> &query){
     // output query to the CL
     for (int i = 0; i < query.size(); i++)
         std::cout << query[i] << ((i == query.size()-1) ? "\n" : ",");
@@ -18,8 +18,9 @@ double CommandLineInputOutput::send_query_recieve_result(std::vector<int> &query
     return result;
 }
 
-void CommandLineInputOutput::output_state(StateSpace &stateSpace){
+void CommandLineInputOutput::output_state(const StateSpace &stateSpace){
     std::vector<double> vec2Output = stateSpace.get_raw_representation();
+    if (vec2Output.size() == 0) return;
     for (int i = 0; i < vec2Output.size(); i++)
-        std::cout << i << (i = vec2Output.size()-1) ? "\n" : " ";
+        std::cout << vec2Output[i] << ((i == vec2Output.size()-1) ? "\n" : " ");
 }

--- a/src/InputOutput/CommandLineInputOutput.cpp
+++ b/src/InputOutput/CommandLineInputOutput.cpp
@@ -14,5 +14,7 @@ double CommandLineInputOutput::send_query_recieve_result(std::vector<int> &query
 }
 
 void CommandLineInputOutput::output_state(StateSpace &stateSpace){
-    return;
+    std::vector<double> vec2Output = stateSpace.get_raw_representation();
+    for (int i = 0; i < vec2Output.size(); i++)
+        std::cout << i << (i = vec2Output.size()-1) ? "\n" : " ";
 }

--- a/src/InputOutput/CommandLineInputOutput.cpp
+++ b/src/InputOutput/CommandLineInputOutput.cpp
@@ -2,11 +2,16 @@
 
 #include "CommandLineInputOutput.hpp"
 
+void CommandLineInputOutput::set_IO(){
+    if (instance == nullptr)
+        instance = new CommandLineInputOutput;
+}
+
 double CommandLineInputOutput::send_query_recieve_result(std::vector<int> &query){
     // output query to the CL
     for (int i = 0; i < query.size(); i++)
         std::cout << query[i] << ((i == query.size()-1) ? "\n" : ",");
-    
+
     double result;
     std::cin >> result;
 

--- a/src/InputOutput/CommandLineInputOutput.cpp
+++ b/src/InputOutput/CommandLineInputOutput.cpp
@@ -5,7 +5,7 @@
 double CommandLineInputOutput::send_query_recieve_result(std::vector<int> &query){
     // output query to the CL
     for (int i = 0; i < query.size(); i++)
-        std::cout << i << (i = query.size()-1) ? "\n" : ",";
+        std::cout << query[i] << ((i == query.size()-1) ? "\n" : ",");
     
     double result;
     std::cin >> result;

--- a/src/InputOutput/CommandLineInputOutput.cpp
+++ b/src/InputOutput/CommandLineInputOutput.cpp
@@ -1,0 +1,18 @@
+#include <iostream>
+
+#include "CommandLineInputOutput.hpp"
+
+double CommandLineInputOutput::send_query_recieve_result(std::vector<int> &query){
+    // output query to the CL
+    for (int i = 0; i < query.size(); i++)
+        std::cout << i << (i = query.size()-1) ? "\n" : ",";
+    
+    double result;
+    std::cin >> result;
+
+    return result;
+}
+
+void CommandLineInputOutput::output_state(StateSpace &stateSpace){
+    return;
+}

--- a/src/InputOutput/CommandLineInputOutput.hpp
+++ b/src/InputOutput/CommandLineInputOutput.hpp
@@ -5,8 +5,6 @@
 #include "InputOutput.hpp"
 
 class CommandLineInputOutput : public InputOutput {
-private:
-    CommandLineInputOutput() = default;
 public:
     double send_query_recieve_result(std::vector<int> &query) override;
     void output_state(StateSpace &stateSpace) override;

--- a/src/InputOutput/CommandLineInputOutput.hpp
+++ b/src/InputOutput/CommandLineInputOutput.hpp
@@ -1,0 +1,15 @@
+#ifndef COMMAND_LINE_IO_H
+#define COMMAND_LINE_IO_H
+#include <vector>
+
+#include "InputOutput.hpp"
+
+class CommandLineInputOutput : public InputOutput {
+private:
+    CommandLineInputOutput() = default;
+public:
+    double send_query_recieve_result(std::vector<int> &query) override;
+    void output_state(StateSpace &stateSpace) override;
+};
+
+#endif // COMMAND_LINE_IO_H

--- a/src/InputOutput/CommandLineInputOutput.hpp
+++ b/src/InputOutput/CommandLineInputOutput.hpp
@@ -5,9 +5,11 @@
 #include "InputOutput.hpp"
 
 class CommandLineInputOutput : public InputOutput {
+    CommandLineInputOutput() = default;
 public:
     double send_query_recieve_result(std::vector<int> &query) override;
     void output_state(StateSpace &stateSpace) override;
+    static void set_IO();
 };
 
 #endif // COMMAND_LINE_IO_H

--- a/src/InputOutput/CommandLineInputOutput.hpp
+++ b/src/InputOutput/CommandLineInputOutput.hpp
@@ -7,8 +7,8 @@
 class CommandLineInputOutput : public InputOutput {
     CommandLineInputOutput() = default;
 public:
-    double send_query_recieve_result(std::vector<int> &query) override;
-    void output_state(StateSpace &stateSpace) override;
+    double send_query_recieve_result(const std::vector<int> &query) override;
+    void output_state(const StateSpace &stateSpace) override;
     static void set_IO();
 };
 

--- a/src/InputOutput/InputOutput.cpp
+++ b/src/InputOutput/InputOutput.cpp
@@ -1,5 +1,13 @@
 #include "InputOutput.hpp"
 
 InputOutput* InputOutput::instance = nullptr;
-InputOutput::InputOutput() { instance = this; }
-InputOutput* InputOutput::get_instance(){ return instance; }
+InputOutput::InputOutput() {
+    if (instance == nullptr)
+        instance = this;
+}
+InputOutput* InputOutput::get_instance(){ 
+    if (instance == nullptr){
+        throw std::runtime_error("IO instance is null - must be set before usage");
+    }
+    return instance; 
+}

--- a/src/InputOutput/InputOutput.cpp
+++ b/src/InputOutput/InputOutput.cpp
@@ -1,0 +1,5 @@
+#include "InputOutput.hpp"
+
+InputOutput* InputOutput::instance = nullptr;
+InputOutput::InputOutput() { instance = this; }
+InputOutput* InputOutput::get_instance(){ return instance; }

--- a/src/InputOutput/InputOutput.hpp
+++ b/src/InputOutput/InputOutput.hpp
@@ -1,21 +1,17 @@
 #ifndef INPUT_OUTPUT_H
 #define INPUT_OUTPUT_H
 #include <vector>
-#include "../StateSpace/StateSpace.cpp"
+#include "../StateSpace/StateSpace.hpp"
 
 class InputOutput {
 protected:
     static InputOutput* instance;
-    InputOutput() { instance = this; }
+    InputOutput();
 public:
-    ~InputOutput() { delete instance; }
-    virtual ~InputOutput() = default;
     virtual double send_query_recieve_result(std::vector<int> &query) = 0;
     virtual void output_state(StateSpace &stateSpace) = 0;
     
-    static InputOutput* get_instance(){
-        return instance;
-    }
+    static InputOutput* get_instance();
 };
 
 #endif // INPUT_OUTPUT_H

--- a/src/InputOutput/InputOutput.hpp
+++ b/src/InputOutput/InputOutput.hpp
@@ -8,8 +8,8 @@ protected:
     static InputOutput* instance;
     InputOutput();
 public:
-    virtual double send_query_recieve_result(std::vector<int> &query) = 0;
-    virtual void output_state(StateSpace &stateSpace) = 0;
+    virtual double send_query_recieve_result(const std::vector<int> &query) = 0;
+    virtual void output_state(const StateSpace &stateSpace) = 0;
     
     static InputOutput* get_instance();
 };

--- a/src/InputOutput/InputOutput.hpp
+++ b/src/InputOutput/InputOutput.hpp
@@ -1,0 +1,20 @@
+#ifndef INPUT_OUTPUT_H
+#define INPUT_OUTPUT_H
+#include <vector>
+#include "../StateSpace/StateSpace.cpp"
+
+class InputOutput {
+protected:
+    static InputOutput* instance;
+    InputOutput() { instance = this; }
+public:
+    virtual ~InputOutput() = default;
+    virtual double send_query_recieve_result(std::vector<int> &query) = 0;
+    virtual void output_state(StateSpace &stateSpace) = 0;
+    
+    static InputOutput* get_instance(){
+        return instance;
+    }
+};
+
+#endif // INPUT_OUTPUT_H

--- a/src/InputOutput/InputOutput.hpp
+++ b/src/InputOutput/InputOutput.hpp
@@ -8,6 +8,7 @@ protected:
     static InputOutput* instance;
     InputOutput() { instance = this; }
 public:
+    ~InputOutput() { delete instance; }
     virtual ~InputOutput() = default;
     virtual double send_query_recieve_result(std::vector<int> &query) = 0;
     virtual void output_state(StateSpace &stateSpace) = 0;

--- a/src/Models/DumbModel.cpp
+++ b/src/Models/DumbModel.cpp
@@ -20,7 +20,7 @@ std::vector<int> DumbModel::get_next_query() {
     return nextQuery;
 }
 
-void DumbModel::update_prediction(std::vector<int> query, double result) {
+void DumbModel::update_prediction(const std::vector<int> &query, double result) {
     stateSpace->set(query, result);
 }
 

--- a/src/Models/DumbModel.hpp
+++ b/src/Models/DumbModel.hpp
@@ -7,7 +7,7 @@ class DumbModel : public Model {
 public:
     DumbModel(int dimensions, int dimensionSize);
     std::vector<int> get_next_query() override;
-    void update_prediction(std::vector<int> query, double result) override;
+    void update_prediction(const std::vector<int> &query, double result) override;
 };
 
 

--- a/src/Models/Model.hpp
+++ b/src/Models/Model.hpp
@@ -10,7 +10,7 @@ protected:
 public:
         Model(int dimensions, int dimensionSize): stateSpace(new StateSpace(dimensions, dimensionSize)) {};
         virtual std::vector<int> get_next_query() = 0;
-        virtual void update_prediction(std::vector<int> query, double result) = 0;
+        virtual void update_prediction(const std::vector<int> &query, double result) = 0;
         StateSpace get_state_space() const { return *stateSpace; };
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,36 @@
-#include <iostream>
+#include <vector>
 
-int main() {
-    std::cout << "Hello from src!" << std::endl;
+#include "InputOutput/CommandLineInputOutput.hpp"
+#include "Models/DumbModel.hpp"
+
+
+void dumbAlgorithm(int dimensions, int dimensionSize, int queries){
+    InputOutput *io = InputOutput::get_instance();
+
+    DumbModel model(dimensions, dimensionSize);
+
+    for (int i = 0; i < queries; i++){
+        std::vector<int> query = model.get_next_query();
+        double result = io->send_query_recieve_result(query);
+        model.update_prediction(query, result);
+    }
+    const auto raw_state = model.get_state_space();
+    io->output_state(raw_state);
+}
+
+int main(int argc, char* argv[]) {
+    if (argc != 4) { // program name + 3 integers
+        std::cerr << "Usage: " << argv[0] << " Dimensions : int,  Array size : int,  Maximum number of queries : int\n";
+        return 1;
+    }
+
+    int dimensions = std::atoi(argv[1]);
+    int dimensionSize = std::atoi(argv[2]);
+    int queries = std::atoi(argv[3]);
+
+    CommandLineInputOutput::set_IO();
+
+    dumbAlgorithm(dimensions, dimensionSize, queries);
+
     return 0;
 }

--- a/test/InputOutputTest.cpp
+++ b/test/InputOutputTest.cpp
@@ -8,17 +8,19 @@ using namespace std;
 
 TEST(TestCommandLine, testCLIOinnit){
     // use clio input output
-    CommandLineInputOutput clio;
+    CommandLineInputOutput::set_IO();
 
     InputOutput* io = InputOutput::get_instance();
     EXPECT_NE(io, nullptr);
-    
+
+    InputOutput* io2 = InputOutput::get_instance();
+    EXPECT_EQ(io, io2);
 }
 
 // basic test of clio with 0d query
 TEST(TestCommandLine, testingCLIO__1){
     // use clio input output
-    CommandLineInputOutput clio;
+    CommandLineInputOutput::set_IO();
 
     InputOutput* io = InputOutput::get_instance();
     
@@ -40,9 +42,9 @@ TEST(TestCommandLine, testingCLIO__1){
 // test with query with non zero values
 TEST(TestCommandLine, testingCLIO__2){
     // use clio input output
-    CommandLineInputOutput clio;
+    CommandLineInputOutput::set_IO();
 
-    InputOutput* io = InputOutput::get_instance();
+    InputOutput *io = InputOutput::get_instance();
     
     // Redirect cout to a stringstream
     std::stringstream buffer;
@@ -62,7 +64,7 @@ TEST(TestCommandLine, testingCLIO__2){
 // test with query size of 1
 TEST(TestCommandLine, testingCLIO__3){
     // use clio input output
-    CommandLineInputOutput clio;
+    CommandLineInputOutput::set_IO();
 
     InputOutput* io = InputOutput::get_instance();
     
@@ -84,7 +86,7 @@ TEST(TestCommandLine, testingCLIO__3){
 // test expected when non num is input
 TEST(TestCommandLine, testingCLIO__4){
     // use clio input output
-    CommandLineInputOutput clio;
+    CommandLineInputOutput::set_IO();
 
     InputOutput* io = InputOutput::get_instance();
     

--- a/test/InputOutputTest.cpp
+++ b/test/InputOutputTest.cpp
@@ -6,41 +6,99 @@
 
 using namespace std;
 
-TEST(TestCommandLine, TestsModel1D){
-    CommandLineInputOutput myModel;
+TEST(TestCommandLine, testCLIOinnit){
+    // use clio input output
+    CommandLineInputOutput clio;
 
-    // test functionality
-    EXPECT_EQ(1, myModel.get_next_query().size());
-    EXPECT_EQ(0, myModel.get_state_space().get({1}));
-    EXPECT_NO_THROW(myModel.update_prediction({1}, 1));
-    EXPECT_EQ(1, myModel.get_state_space().get({1}));
-
-    // check that created array is correct size
-    EXPECT_NO_THROW(myModel.get_state_space().get({0}));
-    EXPECT_NO_THROW(myModel.get_state_space().get({9}));
-    EXPECT_THROW(myModel.get_state_space().get({10}), std::out_of_range);
+    InputOutput* io = InputOutput::get_instance();
+    EXPECT_NE(io, nullptr);
+    
 }
 
-TEST(TestModel, TestsModelND){
-    for (int i = 1; i < 6; i++){
-        DumbModel myModel(i, 10);
-        
-        vector<int> queryPoint(i, 0);
+// basic test of clio with 0d query
+TEST(TestCommandLine, testingCLIO__1){
+    // use clio input output
+    CommandLineInputOutput clio;
 
-        // test functionality
-        EXPECT_EQ(i, myModel.get_next_query().size());
-        EXPECT_EQ(0, myModel.get_state_space().get(queryPoint));
-        EXPECT_NO_THROW(myModel.update_prediction(queryPoint, 1));
-        EXPECT_EQ(1, myModel.get_state_space().get(queryPoint));
+    InputOutput* io = InputOutput::get_instance();
+    
+    // Redirect cout to a stringstream
+    std::stringstream buffer;
+    std::streambuf* oldCout = std::cout.rdbuf(buffer.rdbuf());
 
-        // check that created array is correct size
-        for (int j = 0; j < i; j++){
-            EXPECT_NO_THROW(myModel.get_state_space().get(queryPoint));
-            queryPoint[j] = 9;
-            EXPECT_NO_THROW(myModel.get_state_space().get(queryPoint));
-            queryPoint[j] = 10;
-            EXPECT_THROW(myModel.get_state_space().get(queryPoint), std::out_of_range);
-            queryPoint[j] = 9;
-        }
-    }
+    std::istringstream input("42\n");
+    std::streambuf* oldCin = std::cin.rdbuf(input.rdbuf());
+
+    std::vector<int> query = {0,0,0};
+    double result = io->send_query_recieve_result(query);
+    std::cout.rdbuf(oldCout);
+
+    EXPECT_EQ(result, 42);
+    EXPECT_EQ(buffer.str(), "0,0,0\n");
+}
+
+// test with query with non zero values
+TEST(TestCommandLine, testingCLIO__2){
+    // use clio input output
+    CommandLineInputOutput clio;
+
+    InputOutput* io = InputOutput::get_instance();
+    
+    // Redirect cout to a stringstream
+    std::stringstream buffer;
+    std::streambuf* oldCout = std::cout.rdbuf(buffer.rdbuf());
+
+    std::istringstream input("1.001\n");
+    std::streambuf* oldCin = std::cin.rdbuf(input.rdbuf());
+
+    std::vector<int> query = {1,2,3};
+    double result = io->send_query_recieve_result(query);
+    std::cout.rdbuf(oldCout);
+
+    EXPECT_EQ(result, 1.001);
+    EXPECT_EQ(buffer.str(), "1,2,3\n");
+}
+
+// test with query size of 1
+TEST(TestCommandLine, testingCLIO__3){
+    // use clio input output
+    CommandLineInputOutput clio;
+
+    InputOutput* io = InputOutput::get_instance();
+    
+    // Redirect cout to a stringstream
+    std::stringstream buffer;
+    std::streambuf* oldCout = std::cout.rdbuf(buffer.rdbuf());
+
+    std::istringstream input("1.001\n");
+    std::streambuf* oldCin = std::cin.rdbuf(input.rdbuf());
+
+    std::vector<int> query = {1};
+    double result = io->send_query_recieve_result(query);
+    std::cout.rdbuf(oldCout);
+
+    EXPECT_EQ(result, 1.001);
+    EXPECT_EQ(buffer.str(), "1\n");
+}
+
+// test expected when non num is input
+TEST(TestCommandLine, testingCLIO__4){
+    // use clio input output
+    CommandLineInputOutput clio;
+
+    InputOutput* io = InputOutput::get_instance();
+    
+    // Redirect cout to a stringstream
+    std::stringstream buffer;
+    std::streambuf* oldCout = std::cout.rdbuf(buffer.rdbuf());
+
+    std::istringstream input("test\n");
+    std::streambuf* oldCin = std::cin.rdbuf(input.rdbuf());
+
+    std::vector<int> query = {1,2,3};
+    double result = io->send_query_recieve_result(query);
+    std::cout.rdbuf(oldCout);
+
+    EXPECT_EQ(result, 0);
+    EXPECT_EQ(buffer.str(), "1,2,3\n");
 }

--- a/test/InputOutputTest.cpp
+++ b/test/InputOutputTest.cpp
@@ -1,0 +1,46 @@
+#include <iostream>
+#include <gtest/gtest.h>
+
+#include "../src/InputOutput/InputOutput.hpp"
+#include "../src/InputOutput/CommandLineInputOutput.hpp"
+
+using namespace std;
+
+TEST(TestCommandLine, TestsModel1D){
+    CommandLineInputOutput myModel;
+
+    // test functionality
+    EXPECT_EQ(1, myModel.get_next_query().size());
+    EXPECT_EQ(0, myModel.get_state_space().get({1}));
+    EXPECT_NO_THROW(myModel.update_prediction({1}, 1));
+    EXPECT_EQ(1, myModel.get_state_space().get({1}));
+
+    // check that created array is correct size
+    EXPECT_NO_THROW(myModel.get_state_space().get({0}));
+    EXPECT_NO_THROW(myModel.get_state_space().get({9}));
+    EXPECT_THROW(myModel.get_state_space().get({10}), std::out_of_range);
+}
+
+TEST(TestModel, TestsModelND){
+    for (int i = 1; i < 6; i++){
+        DumbModel myModel(i, 10);
+        
+        vector<int> queryPoint(i, 0);
+
+        // test functionality
+        EXPECT_EQ(i, myModel.get_next_query().size());
+        EXPECT_EQ(0, myModel.get_state_space().get(queryPoint));
+        EXPECT_NO_THROW(myModel.update_prediction(queryPoint, 1));
+        EXPECT_EQ(1, myModel.get_state_space().get(queryPoint));
+
+        // check that created array is correct size
+        for (int j = 0; j < i; j++){
+            EXPECT_NO_THROW(myModel.get_state_space().get(queryPoint));
+            queryPoint[j] = 9;
+            EXPECT_NO_THROW(myModel.get_state_space().get(queryPoint));
+            queryPoint[j] = 10;
+            EXPECT_THROW(myModel.get_state_space().get(queryPoint), std::out_of_range);
+            queryPoint[j] = 9;
+        }
+    }
+}

--- a/test/ModelTest.cpp
+++ b/test/ModelTest.cpp
@@ -1,0 +1,45 @@
+#include <iostream>
+#include <gtest/gtest.h>
+
+#include "../src/Models/DumbModel.hpp"
+
+using namespace std;
+
+TEST(TestModel, TestsModel1D){
+    DumbModel myModel(1, 10);
+
+    // test functionality
+    EXPECT_EQ(1, myModel.get_next_query().size());
+    EXPECT_EQ(0, myModel.get_state_space().get({1}));
+    EXPECT_NO_THROW(myModel.update_prediction({1}, 1));
+    EXPECT_EQ(1, myModel.get_state_space().get({1}));
+
+    // check that created array is correct size
+    EXPECT_NO_THROW(myModel.get_state_space().get({0}));
+    EXPECT_NO_THROW(myModel.get_state_space().get({9}));
+    EXPECT_THROW(myModel.get_state_space().get({10}), std::out_of_range);
+}
+
+TEST(TestModel, TestsModelND){
+    for (int i = 1; i < 6; i++){
+        DumbModel myModel(i, 10);
+        
+        vector<int> queryPoint(i, 0);
+
+        // test functionality
+        EXPECT_EQ(i, myModel.get_next_query().size());
+        EXPECT_EQ(0, myModel.get_state_space().get(queryPoint));
+        EXPECT_NO_THROW(myModel.update_prediction(queryPoint, 1));
+        EXPECT_EQ(1, myModel.get_state_space().get(queryPoint));
+
+        // check that created array is correct size
+        for (int j = 0; j < i; j++){
+            EXPECT_NO_THROW(myModel.get_state_space().get(queryPoint));
+            queryPoint[j] = 9;
+            EXPECT_NO_THROW(myModel.get_state_space().get(queryPoint));
+            queryPoint[j] = 10;
+            EXPECT_THROW(myModel.get_state_space().get(queryPoint), std::out_of_range);
+            queryPoint[j] = 9;
+        }
+    }
+}

--- a/test/StateSpaceTest.cpp
+++ b/test/StateSpaceTest.cpp
@@ -5,14 +5,14 @@
 
 using namespace std;
 
-TEST(OneDimensionAccess, TestsGetAndSetIn1D){
+TEST(TestStateSpace, TestsGetAndSetIn1D){
     StateSpace mySpace(1, 5);
     ASSERT_EQ(0.0, mySpace.get({1}));
     mySpace.set({1}, -1);
     ASSERT_EQ(-1.0, mySpace.get({1}));
 }
 
-TEST(MultDimensionAccess, TestsGetAndSetInND){
+TEST(TestStateSpace, TestsGetAndSetInND){
     for (int i = 1; i < 6; i++){
         StateSpace mySpace(i, 10);
         EXPECT_EQ(i, mySpace.get_dimensions());
@@ -26,7 +26,7 @@ TEST(MultDimensionAccess, TestsGetAndSetInND){
     }
 }
 
-TEST(ErrorThrowing, TestsErrorThrowing){
+TEST(TestStateSpace, TestsErrorThrowing){
     StateSpace mySpace(1, 5);
 
     EXPECT_THROW(mySpace.get({6}), std::out_of_range);

--- a/windows-toolchain.cmake
+++ b/windows-toolchain.cmake
@@ -1,0 +1,11 @@
+# windows-toolchain.cmake
+set(CMAKE_SYSTEM_NAME Windows)
+
+set(CMAKE_C_COMPILER   /usr/bin/x86_64-w64-mingw32-gcc)
+set(CMAKE_CXX_COMPILER /usr/bin/x86_64-w64-mingw32-g++)
+
+set(CMAKE_FIND_ROOT_PATH /usr/x86_64-w64-mingw32)
+
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)


### PR DESCRIPTION
Design Choices:
- IO is a singleton class (only one instance over the life of the program) this allows the same IO method to be accessible over the lifespan of the program and eliminates the possibility of mixing IO methods.

Usage of IO:
1. Init a IO method using the specified set_IO static method in child class e.g. `CommandLineInputOutput::set_IO()`
2. in order to use the IO get the pointer to the object `InputOutput *io = InputOutput::get_instance()` 
then call the desired method `io->{method}` 